### PR TITLE
alu_or_comb.v

### DIFF
--- a/rtl/alu_or_comb.v
+++ b/rtl/alu_or_comb.v
@@ -1,0 +1,12 @@
+module alu_or_comb #(parameter BLOCK = 8) (
+    input  wire [31:0] data_in,
+    output reg  [31:0] result
+);
+    integer i;
+
+    always @(*) begin
+        result = 0;
+        for (i = 0; i < 32/BLOCK; i = i + 1)
+            result[i*BLOCK +: BLOCK] = { {(BLOCK-1){1'b0}}, |data_in[i*BLOCK +: BLOCK] };
+    end
+endmodule


### PR DESCRIPTION
module alu_or_comb #(parameter BLOCK = 8) (
    input  wire [31:0] data_in,
    output reg  [31:0] result
);
    integer i;

    always @(*) begin
        result = 0;
        for (i = 0; i < 32/BLOCK; i = i + 1)
            result[i*BLOCK +: BLOCK] = { {(BLOCK-1){1'b0}}, |data_in[i*BLOCK +: BLOCK] };
    end
endmodule